### PR TITLE
Fixed performInsert to handle GeometryCollections correctly

### DIFF
--- a/src/Eloquent/PostgisTrait.php
+++ b/src/Eloquent/PostgisTrait.php
@@ -24,9 +24,12 @@ trait PostgisTrait
     protected function performInsert(EloquentBuilder $query, array $options = [])
     {
         foreach ($this->attributes as $key => &$value) {
-            if ($value instanceof GeometryInterface) {
+            if ($value instanceof GeometryInterface && ! $value instanceof GeometryCollection) {
                 $this->geometries[$key] = $value; //Preserve the geometry objects prior to the insert
                 $value = $this->getConnection()->raw(sprintf("ST_GeogFromText('%s')", $value->toWKT()));
+            }  else if ($value instanceof GeometryInterface && $value instanceof GeometryCollection) {
+                $this->geometries[$key] = $value; //Preserve the geometry objects prior to the insert
+                $value = $this->getConnection()->raw(sprintf("ST_GeomFromText('%s', 4326)", $value->toWKT()));
             }
         }
 


### PR DESCRIPTION
The geometrycollection method for migrations inserts the column as a geometry column instead of a geography column. This causes saves to fail since the old code here casted everything into a geography when the column required a geometry. This fix takes care of that.
